### PR TITLE
소셜로그인 fix

### DIFF
--- a/app/src/main/java/com/example/memowithtags/common/model/HttpException.kt
+++ b/app/src/main/java/com/example/memowithtags/common/model/HttpException.kt
@@ -1,0 +1,3 @@
+package com.example.memowithtags.common.model
+
+class HttpException(val statusCode: Int, message: String) : Exception(message)

--- a/app/src/main/java/com/example/memowithtags/login/LoginActivity.kt
+++ b/app/src/main/java/com/example/memowithtags/login/LoginActivity.kt
@@ -3,8 +3,10 @@ package com.example.memowithtags.login
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import com.example.memowithtags.common.model.HttpException
 import com.example.memowithtags.databinding.ActivityLoginBinding
 import com.example.memowithtags.login.viewModel.LoginViewModel
 import com.example.memowithtags.mainMemo.MainActivity
@@ -80,6 +82,11 @@ class LoginActivity : AppCompatActivity() {
                 startActivity(intent)
                 this.finish()
             }.onFailure {
+                if (it is HttpException && it.statusCode == 409) {
+                    Toast.makeText(this, "이미 가입된 계정입니다.", Toast.LENGTH_SHORT).show()
+                } else {
+                    Toast.makeText(this, "로그인 실패", Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/memowithtags/signup/repository/AuthRepository.kt
+++ b/app/src/main/java/com/example/memowithtags/signup/repository/AuthRepository.kt
@@ -1,6 +1,7 @@
 package com.example.memowithtags.signup.repository
 
 import android.content.SharedPreferences
+import com.example.memowithtags.common.model.HttpException
 import com.example.memowithtags.common.network.api.AuthApi
 import com.example.memowithtags.common.network.api.ChangeNicknameRequest
 import com.example.memowithtags.common.network.api.ChangeNicknameResponse
@@ -64,7 +65,7 @@ class AuthRepository @Inject constructor(
                     saveRefreshToken(body.refreshToken)
                     onSuccess(response)
                 } else {
-                    onError(Exception("서버 응답 오류: ${response.code()} ${response.message()}"))
+                    onError(HttpException(response.code(), response.message()))
                 }
             }
 


### PR DESCRIPTION
기존 코드는 잘 작동하는데, 이미 가입된 이메일을 통해서 소셜로그인을 하면 막히게끔 서버측에서 설정해서 소셜로그인을 쓸려면 가입된 계정말고 새로운 계정을 써야 될 것 같습니다.
(ex. asdf@gmail.com으로 일반 회원가입을 한 경우, 같은 이메일을 사용하여 카카오나 구글 로그인을 하면 409 에러가 뜹니당)

현재 카카오랑 네이버는 잘 되는데 구글은 서버 쪽 문제가 있어서 나중에 해결하면 될 것 같습니다.

이미 가입된 계정으로 소셜로그인을 시도할 시에 toast 띄워서 이미 가입된 계정이라고 알려주도록 수정했습니다!