### PR TITLE
태그 정렬 구현 및 MainMemo 구조 수정

### DIFF
--- a/app/src/main/java/com/example/memowithtags/common/model/AlphanumComparator.kt
+++ b/app/src/main/java/com/example/memowithtags/common/model/AlphanumComparator.kt
@@ -20,10 +20,11 @@ class AlphanumComparator : Comparator<String> {
         val isDigit1 = c1.all { it.isDigit() }
         val isDigit2 = c2.all { it.isDigit() }
 
-        return if (isDigit1 && isDigit2)
+        return if (isDigit1 && isDigit2) {
             c1.toBigInteger().compareTo(c2.toBigInteger())
-        else
+        } else {
             c1.compareTo(c2)
+        }
     }
 
     private fun String.chunked(): List<String> {

--- a/app/src/main/java/com/example/memowithtags/common/model/AlphanumComparator.kt
+++ b/app/src/main/java/com/example/memowithtags/common/model/AlphanumComparator.kt
@@ -1,0 +1,46 @@
+package com.example.memowithtags.common.model
+
+class AlphanumComparator : Comparator<String> {
+    override fun compare(s1: String, s2: String): Int {
+        val thisChunks = s1.chunked()
+        val thatChunks = s2.chunked()
+        val maxLength = maxOf(thisChunks.size, thatChunks.size)
+
+        for (i in 0 until maxLength) {
+            val thisChunk = thisChunks.getOrNull(i) ?: ""
+            val thatChunk = thatChunks.getOrNull(i) ?: ""
+
+            val result = compareChunk(thisChunk, thatChunk)
+            if (result != 0) return result
+        }
+        return 0
+    }
+
+    private fun compareChunk(c1: String, c2: String): Int {
+        val isDigit1 = c1.all { it.isDigit() }
+        val isDigit2 = c2.all { it.isDigit() }
+
+        return if (isDigit1 && isDigit2)
+            c1.toBigInteger().compareTo(c2.toBigInteger())
+        else
+            c1.compareTo(c2)
+    }
+
+    private fun String.chunked(): List<String> {
+        val result = mutableListOf<String>()
+        var current = ""
+        var lastIsDigit: Boolean? = null
+
+        for (ch in this) {
+            val isDigit = ch.isDigit()
+            if (lastIsDigit != null && isDigit != lastIsDigit) {
+                result.add(current)
+                current = ""
+            }
+            current += ch
+            lastIsDigit = isDigit
+        }
+        if (current.isNotEmpty()) result.add(current)
+        return result
+    }
+}

--- a/app/src/main/java/com/example/memowithtags/common/model/TagSortType.kt
+++ b/app/src/main/java/com/example/memowithtags/common/model/TagSortType.kt
@@ -1,0 +1,15 @@
+package com.example.memowithtags.common.model
+
+enum class TagSortType {
+    ALPHABETIC,
+    COLOR,
+    CREATED;
+
+    override fun toString(): String {
+        return when (this) {
+            ALPHABETIC -> "alphabetic"
+            COLOR -> "color"
+            CREATED -> "created"
+        }
+    }
+}

--- a/app/src/main/java/com/example/memowithtags/common/model/TagSortType.kt
+++ b/app/src/main/java/com/example/memowithtags/common/model/TagSortType.kt
@@ -7,9 +7,9 @@ enum class TagSortType {
 
     override fun toString(): String {
         return when (this) {
-            ALPHABETIC -> "alphabetic"
-            COLOR -> "color"
-            CREATED -> "created"
+            ALPHABETIC -> "ALPHABETIC"
+            COLOR -> "COLOR"
+            CREATED -> "CREATED"
         }
     }
 }

--- a/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/MemoAdapter.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/MemoAdapter.kt
@@ -18,6 +18,7 @@ import com.google.android.flexbox.FlexboxLayout
 import java.util.Locale
 
 class MemoAdapter(
+    private val sortTagIds: (List<Int>) -> List<Int>,
     private val resolveTag: (Int) -> Tag?,
     private val onEditClick: (Memo) -> Unit
 ) : RecyclerView.Adapter<MemoAdapter.MemoViewHolder>() {
@@ -46,7 +47,9 @@ class MemoAdapter(
 
         holder.tagContainer.removeAllViews()
 
-        for (tagId in memo.tagIds) {
+        val sortedTagIds = sortTagIds(memo.tagIds)
+
+        for (tagId in sortedTagIds) {
             val tag = resolveTag(tagId) ?: continue
 
             val tagView = LayoutInflater.from(holder.itemView.context)

--- a/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/MemoAdapter.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/MemoAdapter.kt
@@ -20,10 +20,11 @@ import java.util.Locale
 class MemoAdapter(
     private val sortTagIds: (List<Int>) -> List<Int>,
     private val resolveTag: (Int) -> Tag?,
-    private val onEditClick: (Memo) -> Unit
+    private val onEditClick: (Memo, List<Int>) -> Unit,
+    private val resolveMemo: (Int) -> Memo?
 ) : RecyclerView.Adapter<MemoAdapter.MemoViewHolder>() {
 
-    private var memoList: List<Memo> = emptyList()
+    private var memoList: List<Int> = emptyList()
     private var expandedPosition: Int? = null
 
     inner class MemoViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
@@ -41,7 +42,8 @@ class MemoAdapter(
     override fun getItemCount(): Int = memoList.size
 
     override fun onBindViewHolder(holder: MemoViewHolder, position: Int) {
-        val memo = memoList[position]
+        val memoId = memoList[position]
+        val memo = resolveMemo(memoId) ?: return
         holder.memoContent.text = memo.content
         holder.memoCreated.text = formatDate(memo.createdAt)
 
@@ -93,7 +95,7 @@ class MemoAdapter(
         }
 
         holder.itemView.findViewById<Button>(R.id.editButton).setOnClickListener {
-            onEditClick(memo)
+            onEditClick(memo, sortedTagIds)
         }
     }
 
@@ -107,7 +109,7 @@ class MemoAdapter(
         return outputFormat.format(date)
     }
 
-    fun updateData(newList: List<Memo>) {
+    fun updateData(newList: List<Int>) {
         this.memoList = newList
         notifyDataSetChanged()
     }

--- a/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/SelectedTagAdapter.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/SelectedTagAdapter.kt
@@ -11,27 +11,29 @@ import com.example.memowithtags.R
 import com.example.memowithtags.common.model.Tag
 
 class SelectedTagAdapter(
-    private val onTagUnselect: (Tag) -> Unit
+    private val onTagUnselect: (Int) -> Unit,
+    private val resolveTag: (Int) -> Tag?
 ) : RecyclerView.Adapter<SelectedTagAdapter.TagViewHolder>() {
 
-    private val tags = mutableListOf<Tag>()
+    private val tagIds = mutableListOf<Int>()
 
-    fun submitList(newTags: List<Tag>) {
-        tags.clear()
-        tags.addAll(newTags)
+    fun submitList(newTags: List<Int>) {
+        tagIds.clear()
+        tagIds.addAll(newTags)
         notifyDataSetChanged()
     }
 
     inner class TagViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         private val tagText = view.findViewById<TextView>(R.id.tagText)
 
-        fun bind(tag: Tag) {
+        fun bind(tagId: Int) {
+            val tag = resolveTag(tagId) ?: return
             tagText.text = tag.name
             (tagText.background as? GradientDrawable)?.setColor(
                 try { Color.parseColor(tag.colorHex) } catch (e: IllegalArgumentException) { Color.LTGRAY }
             )
 
-            tagText.setOnClickListener { onTagUnselect(tag) }
+            tagText.setOnClickListener { onTagUnselect(tagId) }
         }
     }
 
@@ -42,8 +44,8 @@ class SelectedTagAdapter(
     }
 
     override fun onBindViewHolder(holder: TagViewHolder, position: Int) {
-        holder.bind(tags[position])
+        holder.bind(tagIds[position])
     }
 
-    override fun getItemCount(): Int = tags.size
+    override fun getItemCount(): Int = tagIds.size
 }

--- a/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/TagAdapter.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/TagAdapter.kt
@@ -11,10 +11,11 @@ import com.example.memowithtags.R
 import com.example.memowithtags.common.model.Tag
 
 class TagAdapter(
-    private val onTagClick: (Tag) -> Unit
+    private val onTagClick: (Int) -> Unit,
+    private val tagResolver: (Int) -> Tag?
 ) : RecyclerView.Adapter<TagAdapter.TagViewHolder>() {
 
-    private var tagList: List<Tag> = emptyList()
+    private var tagList: List<Int> = emptyList()
 
     inner class TagViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val tagName: TextView = itemView.findViewById(R.id.tagText)
@@ -27,11 +28,13 @@ class TagAdapter(
     }
 
     override fun onBindViewHolder(holder: TagViewHolder, position: Int) {
-        val tag = tagList[position]
+        val tagId = tagList[position]
 
         holder.itemView.setOnClickListener {
-            onTagClick(tag)
+            onTagClick(tagId)
         }
+
+        val tag = tagResolver(tagId) ?: return
 
         holder.tagName.text = tag.name
 
@@ -47,7 +50,7 @@ class TagAdapter(
 
     override fun getItemCount(): Int = tagList.size
 
-    fun updateData(newTags: List<Tag>) {
+    fun updateData(newTags: List<Int>) {
         this.tagList = newTags
         notifyDataSetChanged()
     }

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/EditMemoFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/EditMemoFragment.kt
@@ -55,9 +55,7 @@ class EditMemoFragment : Fragment() {
         }
 
         // 태그 recycler view 세팅
-        tagAdapter = TagAdapter() { tag ->
-            tagViewModel.selectTag(tag)
-        }
+        tagAdapter = TagAdapter(tagViewModel::selectTag, tagViewModel::getTag)
         binding.tagRecyclerView.apply {
             layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
             adapter = tagAdapter
@@ -65,15 +63,13 @@ class EditMemoFragment : Fragment() {
 
         tagViewModel.tagList.observe(viewLifecycleOwner) { tagList ->
             val visibleTags = tagList.filter { it.isVisible }
-            tagAdapter.updateData(visibleTags)
+            tagAdapter.updateData(visibleTags.map { it.id })
         }
 
         tagViewModel.getMyTags()
 
         // 선택된 태그 RecyclerView 세팅
-        selectedTagAdapter = SelectedTagAdapter { tag ->
-            tagViewModel.unselectTag(tag)
-        }
+        selectedTagAdapter = SelectedTagAdapter(tagViewModel::unselectTag, tagViewModel::getTag)
 
         binding.selectedTagContainer.apply {
             layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
@@ -81,7 +77,7 @@ class EditMemoFragment : Fragment() {
         }
 
         // observe 변경
-        tagViewModel.selectedTags.observe(viewLifecycleOwner) {
+        tagViewModel.selectedTagIds.observe(viewLifecycleOwner) {
             selectedTagAdapter.submitList(it)
         }
 
@@ -113,7 +109,9 @@ class EditMemoFragment : Fragment() {
 
     private fun handleBackPressed() {
         val content = binding.newMemoText.text.toString()
-        val tagIds = tagViewModel.selectedTags.value?.takeIf { it.isNotEmpty() }?.map { it.id } ?: listOf(0)
+        val tagIds = tagViewModel.selectedTagIds.value
+            ?.takeIf { it.isNotEmpty() }
+            ?: listOf(0)
 
         if (content.isNotBlank()) {
             val editingMemo = memoViewModel.editingMemo.value

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/EditMemoFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/EditMemoFragment.kt
@@ -49,9 +49,7 @@ class EditMemoFragment : Fragment() {
         val tagIds = arguments?.getIntegerArrayList("tagIds") ?: arrayListOf()
 
         if (memoId != -1) {
-            val allTags = tagViewModel.tagList.value ?: emptyList()
-            val selectedTags = allTags.filter { tagIds.contains(it.id) }
-            tagViewModel.setSelectedTags(selectedTags)
+            tagViewModel.setSelectedTags(tagIds)
         }
 
         // 태그 recycler view 세팅

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/MainMemoFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/MainMemoFragment.kt
@@ -51,9 +51,8 @@ class MainMemoFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         // 태그 recycler view 세팅
-        tagAdapter = TagAdapter() { tag ->
-            tagViewModel.selectTag(tag)
-        }
+        tagAdapter = TagAdapter(tagViewModel::selectTag, tagViewModel::getTag)
+
         binding.tagRecyclerView.apply {
             layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
             adapter = tagAdapter
@@ -61,22 +60,26 @@ class MainMemoFragment : Fragment() {
 
         tagViewModel.tagList.observe(viewLifecycleOwner) { tagList ->
             val visibleTags = tagList.filter { it.isVisible }
-            tagAdapter.updateData(visibleTags)
+            tagAdapter.updateData(visibleTags.map { it.id })
             memoAdapter.notifyDataSetChanged()
         }
 
-        tagViewModel.selectedTags.observe(viewLifecycleOwner) {
+        tagViewModel.selectedTagIds.observe(viewLifecycleOwner) {
             renderSelectedTags(it)
         }
 
         tagViewModel.getMyTags()
 
         // 메모 recycler view 세팅
+        val sortTagIds: (List<Int>) -> List<Int> = { tagIds ->
+            tagViewModel.sortTagIds(tagIds)
+        }
+
         val tagResolver: (Int) -> Tag? = { id ->
             tagViewModel.tagList.value?.find { it.id == id }
         }
 
-        memoAdapter = MemoAdapter(tagResolver) { memoToEdit ->
+        memoAdapter = MemoAdapter(sortTagIds, tagResolver) { memoToEdit ->
             memoViewModel.startEditing(memoToEdit)
             binding.newMemoText.setText(memoToEdit.content)
 
@@ -168,11 +171,20 @@ class MainMemoFragment : Fragment() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+
+        // update tags
+        tagViewModel.reloadTags()
+
+        // update memos
+        memoAdapter.notifyDataSetChanged()
+    }
+
     private val postOrUpdateMemoClickListener = View.OnClickListener {
         val content = binding.newMemoText.text.toString()
-        val tagIds = tagViewModel.selectedTags.value
+        val tagIds = tagViewModel.selectedTagIds.value
             ?.takeIf { it.isNotEmpty() }
-            ?.map { it.id }
             ?: listOf(0)
 
         if (content.isNotBlank()) {
@@ -191,10 +203,11 @@ class MainMemoFragment : Fragment() {
         }
     }
 
-    private fun renderSelectedTags(tags: List<Tag>) {
+    private fun renderSelectedTags(tagIds: List<Int>) {
         binding.selectedTagContainer.removeAllViews()
 
-        for (tag in tags) {
+        for (tagId in tagIds) {
+            val tag = tagViewModel.getTag(tagId) ?: continue
             val tagView = LayoutInflater.from(requireContext())
                 .inflate(R.layout.item_selected_tag, binding.selectedTagContainer, false)
 
@@ -211,7 +224,7 @@ class MainMemoFragment : Fragment() {
             }
 
             textView.setOnClickListener {
-                tagViewModel.unselectTag(tag)
+                tagViewModel.unselectTag(tagId)
             }
 
             binding.selectedTagContainer.addView(tagView)

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/MainMemoFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/MainMemoFragment.kt
@@ -17,10 +17,12 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.memowithtags.R
+import com.example.memowithtags.common.model.Memo
 import com.example.memowithtags.common.model.Tag
 import com.example.memowithtags.common.model.tagColors
 import com.example.memowithtags.databinding.FragmentMainMemoBinding
 import com.example.memowithtags.mainMemo.Adapters.MemoAdapter
+import com.example.memowithtags.mainMemo.Adapters.SelectedTagAdapter
 import com.example.memowithtags.mainMemo.Adapters.TagAdapter
 import com.example.memowithtags.mainMemo.viewModel.MemoViewModel
 import com.example.memowithtags.mainMemo.viewModel.TagViewModel
@@ -79,14 +81,13 @@ class MainMemoFragment : Fragment() {
             tagViewModel.tagList.value?.find { it.id == id }
         }
 
-        memoAdapter = MemoAdapter(sortTagIds, tagResolver) { memoToEdit ->
+        val onEditClick: (Memo, List<Int>) -> Unit = onEditClick@{ memoToEdit, tagIds ->
             memoViewModel.startEditing(memoToEdit)
             binding.newMemoText.setText(memoToEdit.content)
-
-            val allTags = tagViewModel.tagList.value ?: return@MemoAdapter
-            val selectedTags = allTags.filter { memoToEdit.tagIds.contains(it.id) }
-            tagViewModel.setSelectedTags(selectedTags)
+            tagViewModel.setSelectedTags(tagIds)
         }
+
+        memoAdapter = MemoAdapter(tagViewModel::sortTagIds, tagViewModel::getTag, onEditClick, memoViewModel::getMemo )
 
         binding.memoRecyclerView.apply {
             layoutManager = LinearLayoutManager(requireContext())
@@ -94,7 +95,7 @@ class MainMemoFragment : Fragment() {
         }
 
         memoViewModel.memoList.observe(viewLifecycleOwner) { memoList ->
-            memoAdapter.updateData(memoList)
+            memoAdapter.updateData(memoList.map { it.id })
         }
 
         memoViewModel.getMyMemos()
@@ -176,6 +177,7 @@ class MainMemoFragment : Fragment() {
 
         // update tags
         tagViewModel.reloadTags()
+        renderSelectedTags(tagViewModel.selectedTagIds.value ?: emptyList())
 
         // update memos
         memoAdapter.notifyDataSetChanged()

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/MainMemoFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/MainMemoFragment.kt
@@ -22,7 +22,6 @@ import com.example.memowithtags.common.model.Tag
 import com.example.memowithtags.common.model.tagColors
 import com.example.memowithtags.databinding.FragmentMainMemoBinding
 import com.example.memowithtags.mainMemo.Adapters.MemoAdapter
-import com.example.memowithtags.mainMemo.Adapters.SelectedTagAdapter
 import com.example.memowithtags.mainMemo.Adapters.TagAdapter
 import com.example.memowithtags.mainMemo.viewModel.MemoViewModel
 import com.example.memowithtags.mainMemo.viewModel.TagViewModel
@@ -87,7 +86,7 @@ class MainMemoFragment : Fragment() {
             tagViewModel.setSelectedTags(tagIds)
         }
 
-        memoAdapter = MemoAdapter(tagViewModel::sortTagIds, tagViewModel::getTag, onEditClick, memoViewModel::getMemo )
+        memoAdapter = MemoAdapter(tagViewModel::sortTagIds, tagViewModel::getTag, onEditClick, memoViewModel::getMemo)
 
         binding.memoRecyclerView.apply {
             layoutManager = LinearLayoutManager(requireContext())

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/MemoViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/MemoViewModel.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MemoViewModel @Inject constructor(
-    private val repository: MemoRepository
+    private val memoRepository: MemoRepository
 ) : ViewModel() {
 
     private val _memoList = MutableLiveData<List<Memo>>(emptyList())
@@ -23,7 +23,7 @@ class MemoViewModel @Inject constructor(
     val editingMemo: LiveData<Memo?> get() = _editingMemo
 
     fun getMyMemos() {
-        repository.getMyMemos(
+        memoRepository.getMyMemos(
             content = null,
             tagIds = null,
             startDate = null,
@@ -37,7 +37,7 @@ class MemoViewModel @Inject constructor(
     fun postMemo(content: String, tagIds: List<Int>) {
         val request = CreateMemoRequest(content, tagIds, false)
 
-        repository.postMemo(
+        memoRepository.postMemo(
             request = request,
             onSuccess = { memo ->
                 getMyMemos()
@@ -55,7 +55,7 @@ class MemoViewModel @Inject constructor(
             locked
         )
 
-        repository.updateMemo(
+        memoRepository.updateMemo(
             memoId = memoId,
             request = request,
             onSuccess = {

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/MemoViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/MemoViewModel.kt
@@ -69,7 +69,7 @@ class MemoViewModel @Inject constructor(
         )
     }
 
-    fun getMemo(memoId: Int) : Memo? {
+    fun getMemo(memoId: Int): Memo? {
         return _memoList.value?.find { it.id == memoId }
     }
 

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/MemoViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/MemoViewModel.kt
@@ -40,6 +40,7 @@ class MemoViewModel @Inject constructor(
         memoRepository.postMemo(
             request = request,
             onSuccess = { memo ->
+                Log.d("MemoViewModel", "메모 등록 성공: $memo")
                 getMyMemos()
             },
             onError = { error ->
@@ -66,6 +67,10 @@ class MemoViewModel @Inject constructor(
                 Log.e("MemoViewModel", "메모 수정 실패", it)
             }
         )
+    }
+
+    fun getMemo(memoId: Int) : Memo? {
+        return _memoList.value?.find { it.id == memoId }
     }
 
     fun startEditing(memo: Memo) {

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/TagViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/TagViewModel.kt
@@ -11,8 +11,6 @@ import com.example.memowithtags.common.model.tagColors
 import com.example.memowithtags.mainMemo.repository.TagRepository
 import com.example.memowithtags.settings.repository.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.text.Collator
-import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/TagViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/TagViewModel.kt
@@ -6,24 +6,26 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.memowithtags.common.model.Tag
 import com.example.memowithtags.mainMemo.repository.TagRepository
+import com.example.memowithtags.settings.repository.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 @HiltViewModel
 class TagViewModel @Inject constructor(
-    private val repository: TagRepository
+    private val tagRepository: TagRepository,
+    private val settingsRepository: SettingsRepository
 ) : ViewModel() {
 
     private val _tagList = MutableLiveData<List<Tag>>(emptyList())
     val tagList: LiveData<List<Tag>> = _tagList
 
-    private val _selectedTags = MutableLiveData<List<Tag>>()
-    val selectedTags: LiveData<List<Tag>> = _selectedTags
+    private val _selectedTagIds = MutableLiveData<List<Int>>()
+    val selectedTagIds: LiveData<List<Int>> = _selectedTagIds
 
     private var initialized = false
 
     fun createTag(name: String, colorHex: String) {
-        repository.createTag(
+        tagRepository.createTag(
             name = name,
             colorHex = colorHex,
             onSuccess = { tag ->
@@ -36,13 +38,15 @@ class TagViewModel @Inject constructor(
         )
     }
 
+    // tagList를 initialize하는 함수
     fun getMyTags() {
         if (initialized) return
         initialized = true
 
-        repository.getMyTags(
+        tagRepository.getMyTags(
             onSuccess = { tagList ->
                 _tagList.value = tagList.map { it.copy(isVisible = true) }
+                sortTag()
             },
             onError = { error ->
                 Log.e("TAG_FETCH", "태그 불러오기 실패: ${error.localizedMessage}")
@@ -50,34 +54,60 @@ class TagViewModel @Inject constructor(
         )
     }
 
-    fun selectTag(tag: Tag) {
-        val updatedTags = _tagList.value?.map {
-            if (it.id == tag.id) it.copy(isVisible = false) else it
-        } ?: return
-        _tagList.value = updatedTags
-
-        val selected = _selectedTags.value.orEmpty().toMutableList().apply { add(tag) }
-        _selectedTags.value = selected
+    // tagList에 속한 tag를 update하는 함수
+    fun reloadTags() {
+        tagRepository.getMyTags(
+            onSuccess = { tagList ->
+                _tagList.value = tagList.map {
+                    if (_selectedTagIds.value?.contains(it.id) == true) {
+                        it.copy(isVisible = false)
+                    } else {
+                        it.copy(isVisible = true)
+                    }
+                }
+                sortTag()
+            },
+            onError = { error ->
+                Log.e("TAG_FETCH", "태그 불러오기 실패: ${error.localizedMessage}")
+            }
+        )
     }
 
-    fun unselectTag(tag: Tag) {
+    // tagId로 tag를 불러오는 함수
+    fun getTag(id: Int): Tag? {
+        return _tagList.value?.find { it.id == id }
+    }
+
+    fun selectTag(tagId: Int) {
         val updatedTags = _tagList.value?.map {
-            if (it.id == tag.id) it.copy(isVisible = true) else it
+            if (it.id == tagId) it.copy(isVisible = false) else it
         } ?: return
         _tagList.value = updatedTags
 
-        val selected = _selectedTags.value.orEmpty().toMutableList().apply { remove(tag) }
-        _selectedTags.value = selected
+        val selected = _selectedTagIds.value.orEmpty().toMutableList().apply { add(tagId) }
+        _selectedTagIds.value = selected
+        sortTag()
+    }
+
+    fun unselectTag(tagId: Int) {
+        val updatedTags = _tagList.value?.map {
+            if (it.id == tagId) it.copy(isVisible = true) else it
+        } ?: return
+        _tagList.value = updatedTags
+
+        val selected = _selectedTagIds.value.orEmpty().toMutableList().apply { remove(tagId) }
+        _selectedTagIds.value = selected
+        sortTag()
     }
 
     fun clearSelectedTags() {
         val updatedTags = _tagList.value?.map { it.copy(isVisible = true) } ?: return
         _tagList.value = updatedTags
-        _selectedTags.value = emptyList()
+        _selectedTagIds.value = emptyList()
     }
 
     fun setSelectedTags(tags: List<Tag>) {
-        _selectedTags.value = tags
+        _selectedTagIds.value = tags.map { it.id }
 
         // visibility 수정하기
         val currentList = _tagList.value ?: return
@@ -89,5 +119,43 @@ class TagViewModel @Inject constructor(
             }
         }
         _tagList.value = updated
+    }
+
+    // tagList와 selectedTags를 정렬하는 함수
+    private fun sortTag() {
+        val currentList = _tagList.value ?: return
+        when (settingsRepository.getTagSortOption()) {
+            "alphabetic" -> {
+                _tagList.value = currentList.sortedBy { it.name }
+            }
+            "color" -> {
+                _tagList.value = currentList.sortedBy { it.colorHex }
+            }
+            "created" -> {
+                _tagList.value = currentList.sortedByDescending { it.createdAt }
+            }
+        }
+        _selectedTagIds.value = sortTagIds(_selectedTagIds.value.orEmpty())
+    }
+
+    // memo의 tagIds를 정렬하는 함수
+    fun sortTagIds(tagIds: List<Int>): List<Int> {
+        if (settingsRepository.getTagSortInMemoOption()) {
+            var sortedIds = tagIds
+            when (settingsRepository.getTagSortOption()) {
+                "alphabetic" -> {
+                    sortedIds.sortedBy { _tagList.value?.find { tag -> tag.id == it }?.name }
+                }
+                "color" -> {
+                    sortedIds.sortedBy { _tagList.value?.find { tag -> tag.id == it }?.colorHex }
+                }
+                "created" -> {
+                    sortedIds.sortedBy { _tagList.value?.find { tag -> tag.id == it }?.createdAt }
+                }
+            }
+            return sortedIds
+        } else {
+            return tagIds
+        }
     }
 }

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/TagViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/TagViewModel.kt
@@ -4,10 +4,15 @@ import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.example.memowithtags.common.model.AlphanumComparator
 import com.example.memowithtags.common.model.Tag
+import com.example.memowithtags.common.model.TagSortType
+import com.example.memowithtags.common.model.tagColors
 import com.example.memowithtags.mainMemo.repository.TagRepository
 import com.example.memowithtags.settings.repository.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.text.Collator
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -24,6 +29,9 @@ class TagViewModel @Inject constructor(
 
     private var initialized = false
 
+    // 이름 정렬을 위한 collator
+    private val collator = AlphanumComparator()
+
     fun createTag(name: String, colorHex: String) {
         tagRepository.createTag(
             name = name,
@@ -31,6 +39,7 @@ class TagViewModel @Inject constructor(
             onSuccess = { tag ->
                 val updated = _tagList.value.orEmpty().toMutableList().apply { add(tag) }
                 _tagList.postValue(updated)
+                sortTag()
             },
             onError = { error ->
                 Log.e("TagViewModel", "태그 생성 실패", error)
@@ -106,13 +115,13 @@ class TagViewModel @Inject constructor(
         _selectedTagIds.value = emptyList()
     }
 
-    fun setSelectedTags(tags: List<Tag>) {
-        _selectedTagIds.value = tags.map { it.id }
+    fun setSelectedTags(tagIds: List<Int>) {
+        _selectedTagIds.value = tagIds
 
         // visibility 수정하기
         val currentList = _tagList.value ?: return
         val updated = currentList.map { tag ->
-            if (tags.any { it.id == tag.id }) {
+            if (tagIds.any { it == tag.id }) {
                 tag.copy(isVisible = false)
             } else {
                 tag.copy(isVisible = true)
@@ -125,13 +134,15 @@ class TagViewModel @Inject constructor(
     private fun sortTag() {
         val currentList = _tagList.value ?: return
         when (settingsRepository.getTagSortOption()) {
-            "alphabetic" -> {
-                _tagList.value = currentList.sortedBy { it.name }
+            TagSortType.ALPHABETIC -> {
+                _tagList.value = currentList.sortedWith(compareBy(collator) { it.name })
             }
-            "color" -> {
-                _tagList.value = currentList.sortedBy { it.colorHex }
+            TagSortType.COLOR -> {
+                _tagList.value = currentList.sortedBy { tag ->
+                    tagColors.indexOf(tag.colorHex).let { if (it != -1) it else Int.MAX_VALUE }
+                }
             }
-            "created" -> {
+            TagSortType.CREATED -> {
                 _tagList.value = currentList.sortedByDescending { it.createdAt }
             }
         }
@@ -141,19 +152,20 @@ class TagViewModel @Inject constructor(
     // memo의 tagIds를 정렬하는 함수
     fun sortTagIds(tagIds: List<Int>): List<Int> {
         if (settingsRepository.getTagSortInMemoOption()) {
-            var sortedIds = tagIds
-            when (settingsRepository.getTagSortOption()) {
-                "alphabetic" -> {
-                    sortedIds.sortedBy { _tagList.value?.find { tag -> tag.id == it }?.name }
+            return when (settingsRepository.getTagSortOption()) {
+                TagSortType.ALPHABETIC -> {
+                    tagIds.sortedWith(compareBy(collator) { _tagList.value?.find { tag -> tag.id == it }?.name.toString() })
                 }
-                "color" -> {
-                    sortedIds.sortedBy { _tagList.value?.find { tag -> tag.id == it }?.colorHex }
+                TagSortType.COLOR -> {
+                    tagIds.sortedBy { tagId ->
+                        val color = _tagList.value?.find { it.id == tagId }?.colorHex
+                        tagColors.indexOf(color).let { if (it != -1) it else Int.MAX_VALUE }
+                    }
                 }
-                "created" -> {
-                    sortedIds.sortedBy { _tagList.value?.find { tag -> tag.id == it }?.createdAt }
+                TagSortType.CREATED -> {
+                    tagIds.sortedBy { _tagList.value?.find { tag -> tag.id == it }?.createdAt }
                 }
             }
-            return sortedIds
         } else {
             return tagIds
         }

--- a/app/src/main/java/com/example/memowithtags/settings/fragments/TagSettingsFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/settings/fragments/TagSettingsFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.example.memowithtags.R
+import com.example.memowithtags.common.model.TagSortType
 import com.example.memowithtags.databinding.FragmentTagSettingsBinding
 import com.example.memowithtags.settings.adapters.TagAdapter
 import com.example.memowithtags.settings.viewModel.TagSettingsViewModel
@@ -52,15 +53,15 @@ class TagSettingsFragment : Fragment() {
 
         // 태그 정렬 세팅
         binding.tagSortAlphabeticLayout.setOnClickListener {
-            tagSettingsViewModel.setTagSortOption("alphabetic")
+            tagSettingsViewModel.setTagSortOption(TagSortType.ALPHABETIC)
         }
 
         binding.tagSortColorLayout.setOnClickListener {
-            tagSettingsViewModel.setTagSortOption("color")
+            tagSettingsViewModel.setTagSortOption(TagSortType.COLOR)
         }
 
         binding.tagSortCreatedLayout.setOnClickListener {
-            tagSettingsViewModel.setTagSortOption("created")
+            tagSettingsViewModel.setTagSortOption(TagSortType.CREATED)
         }
 
         // 메모 내 태그 정렬 옵션
@@ -80,15 +81,15 @@ class TagSettingsFragment : Fragment() {
     private fun observeViewModel() {
         // 태그 정렬 세팅
         tagSettingsViewModel.tagSortOption.observe(viewLifecycleOwner) { option ->
-            if (option == "alphabetic") {
+            if (option == TagSortType.ALPHABETIC) {
                 binding.tagSortCheckAlphabetic.imageTintList = resources.getColorStateList(R.color.colorChecked, null)
                 binding.tagSortCheckColor.imageTintList = resources.getColorStateList(R.color.colorUnchecked, null)
                 binding.tagSortCheckCreated.imageTintList = resources.getColorStateList(R.color.colorUnchecked, null)
-            } else if (option == "color") {
+            } else if (option == TagSortType.COLOR) {
                 binding.tagSortCheckAlphabetic.imageTintList = resources.getColorStateList(R.color.colorUnchecked, null)
                 binding.tagSortCheckColor.imageTintList = resources.getColorStateList(R.color.colorChecked, null)
                 binding.tagSortCheckCreated.imageTintList = resources.getColorStateList(R.color.colorUnchecked, null)
-            } else if (option == "created") {
+            } else if (option == TagSortType.CREATED) {
                 binding.tagSortCheckAlphabetic.imageTintList = resources.getColorStateList(R.color.colorUnchecked, null)
                 binding.tagSortCheckColor.imageTintList = resources.getColorStateList(R.color.colorUnchecked, null)
                 binding.tagSortCheckCreated.imageTintList = resources.getColorStateList(R.color.colorChecked, null)

--- a/app/src/main/java/com/example/memowithtags/settings/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/example/memowithtags/settings/repository/SettingsRepository.kt
@@ -20,8 +20,13 @@ class SettingsRepository @Inject constructor(
         return prefs.getString("text_size_option", null)
     }
 
-    fun getTagSortOption(): String? {
-        return prefs.getString("tag_sort_option", TagSortType.CREATED.toString())
+    fun getTagSortOption(): TagSortType {
+        return try {
+            val name = prefs.getString("tag_sort_option", null)
+            TagSortType.valueOf(name ?: return TagSortType.CREATED)
+        } catch (e: IllegalArgumentException) {
+            TagSortType.CREATED
+        }
     }
 
     fun getTagSortInMemoOption(): Boolean {
@@ -40,8 +45,8 @@ class SettingsRepository @Inject constructor(
         prefs.edit() { putString("text_size_option", option) }
     }
 
-    fun setTagSortOption(option: String) {
-        prefs.edit() { putString("tag_sort_option", option) }
+    fun setTagSortOption(option: TagSortType) {
+        prefs.edit() { putString("tag_sort_option", option.toString()) }
     }
 
     fun setTagSortInMemoOption(option: Boolean) {

--- a/app/src/main/java/com/example/memowithtags/settings/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/example/memowithtags/settings/repository/SettingsRepository.kt
@@ -2,6 +2,7 @@ package com.example.memowithtags.settings.repository
 
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import com.example.memowithtags.common.model.TagSortType
 import javax.inject.Inject
 
 class SettingsRepository @Inject constructor(
@@ -20,7 +21,7 @@ class SettingsRepository @Inject constructor(
     }
 
     fun getTagSortOption(): String? {
-        return prefs.getString("tag_sort_option", null)
+        return prefs.getString("tag_sort_option", TagSortType.CREATED.toString())
     }
 
     fun getTagSortInMemoOption(): Boolean {

--- a/app/src/main/java/com/example/memowithtags/settings/viewModel/TagSettingsViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/settings/viewModel/TagSettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.example.memowithtags.common.model.Tag
+import com.example.memowithtags.common.model.TagSortType
 import com.example.memowithtags.common.network.api.TagResponse
 import com.example.memowithtags.mainMemo.repository.TagRepository
 import com.example.memowithtags.settings.repository.SettingsRepository
@@ -21,8 +22,8 @@ class TagSettingsViewModel @Inject constructor(
     private val _tagList = MutableLiveData<List<Tag>>(emptyList())
     val tagList: LiveData<List<Tag>> = _tagList
 
-    private val _tagSortOption = MutableLiveData<String>()
-    val tagSortOption: LiveData<String> get() = _tagSortOption
+    private val _tagSortOption = MutableLiveData<TagSortType>()
+    val tagSortOption: LiveData<TagSortType> get() = _tagSortOption
 
     private val _tagSortInMemoOption = MutableLiveData<Boolean>()
     val tagSortInMemoOption: LiveData<Boolean> get() = _tagSortInMemoOption
@@ -54,15 +55,12 @@ class TagSettingsViewModel @Inject constructor(
         )
 
         // initialize tag sort option
-        if (settingsRepository.getTagSortOption() == null) {
-            settingsRepository.setTagSortOption("created")
-        }
         _tagSortOption.value = settingsRepository.getTagSortOption()
 
         _tagSortInMemoOption.value = settingsRepository.getTagSortInMemoOption()
     }
 
-    fun setTagSortOption(option: String) {
+    fun setTagSortOption(option: TagSortType) {
         settingsRepository.setTagSortOption(option)
         _tagSortOption.value = option
     }


### PR DESCRIPTION
태그 정렬 기능을 구현했습니다ㅏㅏㅏㅏ

태그 정렬 기능을 구현하면서 MainMemo관련해서 구조를 좀 바꿨습니다. 기존의 구조가 Adaptor에서 ViewModel을 통해 데이터를 받고 이를 Adaptor 내부에 저장하는 구조였는데 (ex. TagAdaptor안에 tagList나 MemoAdaptor안에 memoList) 이럴 경우 ViewModel에서 데이터 수정이 일어날 경우, Adaptor 내부 데이터까지 변경해주어야 돼서 되게 번거로워요

수정한 구조에서는 Adaptor에서는 Tag나 Memo의 Id만 저장하고, 해당 Id에 해당하는 데이터는 resolveTag, resolveMemo 이런 식으로 callable를 Adaptor 선언할 때 받아와서 Adaptor안에서 ViewModel로부터 데이터를 direct하게 받아올 수 있도록 모두 수정했습니다. 이러면 Tag나 Memo의 속성이 바뀌어도 Adaptor 내부의 데이터를 수정할 필요없이 ViewModel 내부의 데이터만 수정하면 정상적으로 작동하게 됩니다.

이렇게 구조를 바꾸면 모든 데이터는 ViewModel 내부에서 관리가 되어서 앞으로 작업할 때 좀 더 편할 것 같아요

조금 더 덧붙여서 설명하자면 안드로이드 앱을 개발할 때 MVVM(Model-View-ViewModel /  Model, View, ViewModel 각각의 로직을 최대한 분리하여 유지보수성 & 테스트성을 높이는 방법)이라는 Architecture를 사용하는게 일반적인 것 같은데 이번에 태그 정렬 기능을 구현하면서 ViewModel과 View 쪽의 로직이 충분히 분리되지 않아 좀 어려움이 있었습니다 ㅠㅠ. 지금 계속 코드가 복잡해지고 있어서 이런 아키텍쳐 부분을 좀 더 신경쓰면서 개발하면 좋을 것 같아요!

설명이 좀 길어졌지만 나름대로(?) 좀 아키텍쳐를 신경써서 구조를 수정해보았는데 좀 더 좋은 방안이 있으면 알려주시면 감사하겠습니다 :)

(제가 main memo쪽 코드를 좀 많이 건드려서 `feature/search-page` 작업하실 때 한 번 develop branch merge해서 이어서 작업하시면 좋을 것 같습니다. 아니면 나중에 branch 병합할 때 conflict가 많이 뜰 것 같아요...)
