### PR TITLE
검색 기능 구현

### DIFF
--- a/app/src/main/java/com/example/memowithtags/common/network/api/ApiModels.kt
+++ b/app/src/main/java/com/example/memowithtags/common/network/api/ApiModels.kt
@@ -147,4 +147,3 @@ data class SocialLoginResponse(
     val refreshToken: String,
     val isNewUser: Boolean
 )
-

--- a/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/MemoAdapter.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/MemoAdapter.kt
@@ -22,7 +22,7 @@ class MemoAdapter(
     private val sortTagIds: (List<Int>) -> List<Int>,
     private val resolveTag: (Int) -> Tag?,
 
-    private val onEditClick: ((Memo, List<Int>) -> Unit) ?= null,
+    private val onEditClick: ((Memo, List<Int>) -> Unit) ? = null,
     private val resolveMemo: (Int) -> Memo?
 
 ) : RecyclerView.Adapter<MemoAdapter.MemoViewHolder>() {

--- a/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/MemoAdapter.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/MemoAdapter.kt
@@ -4,6 +4,7 @@ import android.graphics.Color
 import android.graphics.drawable.GradientDrawable
 import android.icu.text.SimpleDateFormat
 import android.icu.util.TimeZone
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -45,7 +46,15 @@ class MemoAdapter(
 
     override fun onBindViewHolder(holder: MemoViewHolder, position: Int) {
         val memoId = memoList[position]
-        val memo = resolveMemo(memoId) ?: return
+        Log.d("MemoAdapter", "memoId[$position] = $memoId")
+
+        val memo = resolveMemo(memoId)
+        if (memo == null) {
+            Log.d("MemoAdapter", "resolveMemo($memoId) → null")
+            return
+        } else {
+            Log.d("MemoAdapter", "resolveMemo($memoId) → content = ${memo.content}, tagIds = ${memo.tagIds}, createdAt = ${memo.createdAt}")
+        }
         holder.memoContent.text = memo.content
         holder.memoCreated.text = formatDate(memo.createdAt)
 

--- a/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/MemoAdapter.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/MemoAdapter.kt
@@ -22,6 +22,7 @@ class MemoAdapter(
     private val sortTagIds: (List<Int>) -> List<Int>,
     private val resolveTag: (Int) -> Tag?,
 
+    private val onSearchClick: ((Memo) -> Unit) ? = null,
     private val onEditClick: ((Memo, List<Int>) -> Unit) ? = null,
     private val resolveMemo: (Int) -> Memo?
 
@@ -103,6 +104,10 @@ class MemoAdapter(
                 notifyItemChanged(previousExpanded ?: -1)
                 notifyItemChanged(position)
             }
+        }
+
+        holder.itemView.findViewById<Button>(R.id.searchButton).setOnClickListener {
+            onSearchClick?.let { it1 -> it1(memo) }
         }
 
         holder.itemView.findViewById<Button>(R.id.editButton).setOnClickListener {

--- a/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/MemoAdapter.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/Adapters/MemoAdapter.kt
@@ -97,7 +97,7 @@ class MemoAdapter(
         }
 
         holder.itemView.findViewById<Button>(R.id.editButton).setOnClickListener {
-            onEditClick(memo, sortedTagIds)
+            onEditClick?.let { it1 -> it1(memo, sortedTagIds) }
         }
     }
 

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/EditMemoFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/EditMemoFragment.kt
@@ -10,7 +10,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.example.memowithtags.R
 import com.example.memowithtags.databinding.FragmentEditMemoBinding
 import com.example.memowithtags.mainMemo.Adapters.SelectedTagAdapter
 import com.example.memowithtags.mainMemo.Adapters.TagAdapter

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/EditMemoFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/EditMemoFragment.kt
@@ -129,6 +129,6 @@ class EditMemoFragment : Fragment() {
             tagViewModel.clearSelectedTags()
         }
 
-        findNavController().navigate(R.id.action_editMemo_to_mainMemo)
+        findNavController().popBackStack()
     }
 }

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/MainMemoFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/MainMemoFragment.kt
@@ -18,7 +18,6 @@ import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.memowithtags.R
 import com.example.memowithtags.common.model.Memo
-import com.example.memowithtags.common.model.Tag
 import com.example.memowithtags.common.model.tagColors
 import com.example.memowithtags.databinding.FragmentMainMemoBinding
 import com.example.memowithtags.mainMemo.Adapters.MemoAdapter

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/MainMemoFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/MainMemoFragment.kt
@@ -72,14 +72,6 @@ class MainMemoFragment : Fragment() {
         tagViewModel.getMyTags()
 
         // 메모 recycler view 세팅
-        val sortTagIds: (List<Int>) -> List<Int> = { tagIds ->
-            tagViewModel.sortTagIds(tagIds)
-        }
-
-        val tagResolver: (Int) -> Tag? = { id ->
-            tagViewModel.tagList.value?.find { it.id == id }
-        }
-
         val onEditClick: (Memo, List<Int>) -> Unit = onEditClick@{ memoToEdit, tagIds ->
             memoViewModel.startEditing(memoToEdit)
             binding.newMemoText.setText(memoToEdit.content)

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/MainMemoFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/MainMemoFragment.kt
@@ -170,7 +170,7 @@ class MainMemoFragment : Fragment() {
             startActivity(intent)
         }
 
-        //검색 버튼
+        // 검색 버튼
         binding.iconSearch.setOnClickListener {
             findNavController().navigate(R.id.action_mainMemo_to_search)
         }

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/MainMemoFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/MainMemoFragment.kt
@@ -72,13 +72,26 @@ class MainMemoFragment : Fragment() {
         tagViewModel.getMyTags()
 
         // 메모 recycler view 세팅
+        val onSearchClick: (Memo) -> Unit = { memo ->
+            val bundle = Bundle().apply {
+                putString("memoContent", memo.content)
+            }
+            findNavController().navigate(R.id.action_mainMemo_to_search, bundle)
+        }
+
         val onEditClick: (Memo, List<Int>) -> Unit = onEditClick@{ memoToEdit, tagIds ->
             memoViewModel.startEditing(memoToEdit)
             binding.newMemoText.setText(memoToEdit.content)
             tagViewModel.setSelectedTags(tagIds)
         }
 
-        memoAdapter = MemoAdapter(tagViewModel::sortTagIds, tagViewModel::getTag, onEditClick, memoViewModel::getMemo)
+        memoAdapter = MemoAdapter(
+            tagViewModel::sortTagIds,
+            tagViewModel::getTag,
+            onSearchClick,
+            onEditClick,
+            memoViewModel::getMemo
+        )
 
         binding.memoRecyclerView.apply {
             layoutManager = LinearLayoutManager(requireContext())
@@ -153,6 +166,8 @@ class MainMemoFragment : Fragment() {
                     putIntegerArrayList("tagIds", ArrayList(editingMemo.tagIds))
                 }
             }
+            binding.tagInputEditText.text.clear()
+            binding.newMemoText.text.clear()
             findNavController().navigate(R.id.action_mainMemo_to_editMemo, bundle)
         }
 

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/SearchFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/SearchFragment.kt
@@ -48,6 +48,14 @@ class SearchFragment : Fragment() {
 
         tagViewModel.setIsSearching(true)
 
+        // 메모 검색을 통해 진입 시
+        val content = arguments?.getString("memoContent")
+        if (content != null) {
+            binding.searchText.setText(content)
+            searchViewModel.updateQuery(content)
+            tagViewModel.updateQuery(content)
+        }
+
         // Tag RecyclerView 연결
         searchTagAdapter = TagAdapter(tagViewModel::selectTag, tagViewModel::getTag)
 
@@ -61,9 +69,16 @@ class SearchFragment : Fragment() {
         }
 
         // Memo RecyclerView 연결
+        val onSearchClick: (Memo) -> Unit = { memo ->
+            binding.searchText.setText(memo.content)
+            searchViewModel.updateQuery(memo.content)
+            tagViewModel.updateQuery(memo.content)
+        }
+
         memoAdapter = MemoAdapter(
             tagViewModel::sortTagIds,
             tagViewModel::getTag,
+            onSearchClick,
             null,
             memoViewModel::getMemo
         )

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/SearchFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/SearchFragment.kt
@@ -39,7 +39,7 @@ class SearchFragment : Fragment() {
         return binding.root
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?){
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         tagViewModel.getMyTags()
@@ -68,12 +68,11 @@ class SearchFragment : Fragment() {
         // ViewModel에서 결과 수신
         searchViewModel.memoSearchResult.observe(viewLifecycleOwner) { memoList ->
             Log.d("SearchFragment", "검색 결과 memoList.size = ${memoList.size}")
-            memoViewModel.cacheSearchResult(memoList)
-
-            memoAdapter.updateData(memoList.map { it.id })
+            memoViewModel.cacheSearchResultFromIds(memoList)
+            memoAdapter.updateData(memoList)
         }
 
-        binding.leftArrowIcon.setOnClickListener{
+        binding.leftArrowIcon.setOnClickListener {
             findNavController().navigate(R.id.action_search_to_mainMemo)
         }
     }

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/SearchFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/SearchFragment.kt
@@ -8,12 +8,15 @@ import android.view.ViewGroup
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.memowithtags.R
+import com.example.memowithtags.common.model.Memo
 import com.example.memowithtags.common.model.Tag
 import com.example.memowithtags.databinding.FragmentSearchBinding
 import com.example.memowithtags.mainMemo.Adapters.MemoAdapter
+import com.example.memowithtags.mainMemo.Adapters.TagAdapter
 import com.example.memowithtags.mainMemo.viewModel.MemoViewModel
 import com.example.memowithtags.mainMemo.viewModel.SearchViewModel
 import com.example.memowithtags.mainMemo.viewModel.TagViewModel
@@ -24,11 +27,12 @@ class SearchFragment : Fragment() {
     private var _binding: FragmentSearchBinding? = null
     private val binding get() = _binding!!
 
-    private val searchViewModel: SearchViewModel by activityViewModels()
+    private val searchViewModel: SearchViewModel by viewModels()
     private val tagViewModel: TagViewModel by activityViewModels()
     private val memoViewModel: MemoViewModel by activityViewModels()
 
     private lateinit var memoAdapter: MemoAdapter
+    private lateinit var searchTagAdapter: TagAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -42,38 +46,52 @@ class SearchFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        tagViewModel.getMyTags()
+        tagViewModel.setIsSearching(true)
 
-        // 메모 recycler view 세팅
-        val sortTagIds: (List<Int>) -> List<Int> = { tagIds ->
-            tagViewModel.sortTagIds(tagIds)
+        // Tag RecyclerView 연결
+        searchTagAdapter = TagAdapter(tagViewModel::selectTag, tagViewModel::getTag)
+
+        binding.searchtagRecyclerView.apply {
+            layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
+            adapter = searchTagAdapter
         }
 
-        // RecyclerView 연결
-        val tagResolver: (Int) -> Tag? = { id ->
-            tagViewModel.tagList.value?.find { it.id == id }
+        tagViewModel.tagSearchResult.observe(viewLifecycleOwner) { tagList ->
+            searchTagAdapter.updateData(tagList)
         }
 
-        memoAdapter = MemoAdapter(tagViewModel::sortTagIds, tagViewModel::getTag, null, memoViewModel::getMemo)
-        binding.searchmemoRecyclerView.adapter = memoAdapter
-        binding.searchmemoRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+        // Memo RecyclerView 연결
+        memoAdapter = MemoAdapter(
+            tagViewModel::sortTagIds,
+            tagViewModel::getTag,
+            null,
+            memoViewModel::getMemo
+        )
 
-        memoViewModel.getMyMemos()
+        binding.searchmemoRecyclerView.apply {
+            adapter = memoAdapter
+            layoutManager = LinearLayoutManager(requireContext())
+        }
 
         // 검색어 입력 감지
         binding.searchText.addTextChangedListener {
             searchViewModel.updateQuery(it.toString())
+            tagViewModel.updateQuery(it.toString())
         }
 
         // ViewModel에서 결과 수신
         searchViewModel.memoSearchResult.observe(viewLifecycleOwner) { memoList ->
             Log.d("SearchFragment", "검색 결과 memoList.size = ${memoList.size}")
-            memoViewModel.cacheSearchResultFromIds(memoList)
             memoAdapter.updateData(memoList)
         }
 
         binding.leftArrowIcon.setOnClickListener {
-            findNavController().navigate(R.id.action_search_to_mainMemo)
+            findNavController().popBackStack()
         }
+    }
+
+    override fun onDestroy() {
+        tagViewModel.clearSearch()
+        super.onDestroy()
     }
 }

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/SearchFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/SearchFragment.kt
@@ -1,6 +1,7 @@
 package com.example.memowithtags.mainMemo.fragments
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,15 +14,19 @@ import com.example.memowithtags.R
 import com.example.memowithtags.common.model.Tag
 import com.example.memowithtags.databinding.FragmentSearchBinding
 import com.example.memowithtags.mainMemo.Adapters.MemoAdapter
+import com.example.memowithtags.mainMemo.viewModel.MemoViewModel
 import com.example.memowithtags.mainMemo.viewModel.SearchViewModel
 import com.example.memowithtags.mainMemo.viewModel.TagViewModel
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class SearchFragment : Fragment() {
     private var _binding: FragmentSearchBinding? = null
     private val binding get() = _binding!!
 
     private val searchViewModel: SearchViewModel by activityViewModels()
     private val tagViewModel: TagViewModel by activityViewModels()
+    private val memoViewModel: MemoViewModel by activityViewModels()
 
     private lateinit var memoAdapter: MemoAdapter
 
@@ -37,14 +42,23 @@ class SearchFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?){
         super.onViewCreated(view, savedInstanceState)
 
+        tagViewModel.getMyTags()
+
+        // 메모 recycler view 세팅
+        val sortTagIds: (List<Int>) -> List<Int> = { tagIds ->
+            tagViewModel.sortTagIds(tagIds)
+        }
+
         // RecyclerView 연결
         val tagResolver: (Int) -> Tag? = { id ->
             tagViewModel.tagList.value?.find { it.id == id }
         }
 
-        memoAdapter = MemoAdapter(tagResolver)
+        memoAdapter = MemoAdapter(tagViewModel::sortTagIds, tagViewModel::getTag, null, memoViewModel::getMemo)
         binding.searchmemoRecyclerView.adapter = memoAdapter
         binding.searchmemoRecyclerView.layoutManager = LinearLayoutManager(requireContext())
+
+        memoViewModel.getMyMemos()
 
         // 검색어 입력 감지
         binding.searchText.addTextChangedListener {
@@ -52,8 +66,11 @@ class SearchFragment : Fragment() {
         }
 
         // ViewModel에서 결과 수신
-        searchViewModel.memoSearchResult.observe(viewLifecycleOwner) { memos ->
-            memoAdapter.updateData(memos)
+        searchViewModel.memoSearchResult.observe(viewLifecycleOwner) { memoList ->
+            Log.d("SearchFragment", "검색 결과 memoList.size = ${memoList.size}")
+            memoViewModel.cacheSearchResult(memoList)
+
+            memoAdapter.updateData(memoList.map { it.id })
         }
 
         binding.leftArrowIcon.setOnClickListener{

--- a/app/src/main/java/com/example/memowithtags/mainMemo/fragments/SearchFragment.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/fragments/SearchFragment.kt
@@ -11,9 +11,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.example.memowithtags.R
 import com.example.memowithtags.common.model.Memo
-import com.example.memowithtags.common.model.Tag
 import com.example.memowithtags.databinding.FragmentSearchBinding
 import com.example.memowithtags.mainMemo.Adapters.MemoAdapter
 import com.example.memowithtags.mainMemo.Adapters.TagAdapter

--- a/app/src/main/java/com/example/memowithtags/mainMemo/repository/MemoRepository.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/repository/MemoRepository.kt
@@ -4,7 +4,6 @@ import com.example.memowithtags.common.model.Memo
 import com.example.memowithtags.common.network.api.CreateMemoRequest
 import com.example.memowithtags.common.network.api.CreateMemoResponse
 import com.example.memowithtags.common.network.api.MemoApi
-import com.example.memowithtags.common.network.api.SearchMemoRequest
 import com.example.memowithtags.common.network.api.SearchMemoResponse
 import com.example.memowithtags.common.network.api.UpdateMemoRequest
 import retrofit2.Call
@@ -129,22 +128,21 @@ class MemoRepository @Inject constructor(
     ) {
         memoApi.searchMemo(content, tagIds, startDate, endDate, page)
             .enqueue(object : Callback<SearchMemoResponse> {
-            override fun onResponse(
-                call: Call<SearchMemoResponse>,
-                response: Response<SearchMemoResponse>
-            ) {
-                if (response.isSuccessful) {
-                    val body = response.body()
-                    callback(body?.results ?: emptyList())
-                } else {
-                    onError(Exception("Response not successful: ${response.code()}"))
+                override fun onResponse(
+                    call: Call<SearchMemoResponse>,
+                    response: Response<SearchMemoResponse>
+                ) {
+                    if (response.isSuccessful) {
+                        val body = response.body()
+                        callback(body?.results ?: emptyList())
+                    } else {
+                        onError(Exception("Response not successful: ${response.code()}"))
+                    }
                 }
-            }
 
-            override fun onFailure(call: Call<SearchMemoResponse>, t: Throwable) {
-                onError(t)
-            }
-        })
+                override fun onFailure(call: Call<SearchMemoResponse>, t: Throwable) {
+                    onError(t)
+                }
+            })
     }
-
 }

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/MemoViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/MemoViewModel.kt
@@ -22,6 +22,8 @@ class MemoViewModel @Inject constructor(
     private val _editingMemo = MutableLiveData<Memo?>()
     val editingMemo: LiveData<Memo?> get() = _editingMemo
 
+    private val memoMap = mutableMapOf<Int, Memo>()
+
     fun getMyMemos() {
         memoRepository.getMyMemos(
             content = null,
@@ -70,7 +72,20 @@ class MemoViewModel @Inject constructor(
     }
 
     fun getMemo(memoId: Int): Memo? {
-        return _memoList.value?.find { it.id == memoId }
+        val memo = memoMap[memoId] ?: _memoList.value?.find { it.id == memoId }
+        if (memo != null) {
+            Log.d("MemoViewModel", "getMemo($memoId) → ${memo.content}")
+        } else {
+            Log.d("MemoViewModel", "getMemo($memoId) → null")
+        }
+        return memo
+    }
+
+    fun cacheSearchResult(memos: List<Memo>) {
+        for (memo in memos) {
+            Log.d("MemoViewModel", "캐싱됨: id=${memo.id}, content=${memo.content}")
+            memoMap[memo.id] = memo
+        }
     }
 
     fun startEditing(memo: Memo) {

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/MemoViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/MemoViewModel.kt
@@ -10,7 +10,6 @@ import com.example.memowithtags.common.network.api.UpdateMemoRequest
 import com.example.memowithtags.mainMemo.repository.MemoRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableStateFlow
 
 @HiltViewModel
 class MemoViewModel @Inject constructor(
@@ -24,7 +23,6 @@ class MemoViewModel @Inject constructor(
     // 현재 수정 중인 Memo
     private val _editingMemo = MutableLiveData<Memo?>()
     val editingMemo: LiveData<Memo?> get() = _editingMemo
-
 
     fun getMyMemos() {
         memoRepository.getMyMemos(
@@ -82,7 +80,6 @@ class MemoViewModel @Inject constructor(
         }
         return memo
     }
-
 
     fun startEditing(memo: Memo) {
         _editingMemo.value = memo

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/MemoViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/MemoViewModel.kt
@@ -10,19 +10,21 @@ import com.example.memowithtags.common.network.api.UpdateMemoRequest
 import com.example.memowithtags.mainMemo.repository.MemoRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
 
 @HiltViewModel
 class MemoViewModel @Inject constructor(
     private val memoRepository: MemoRepository
 ) : ViewModel() {
 
+    // Memo 정보를 저장하는 List
     private val _memoList = MutableLiveData<List<Memo>>(emptyList())
     val memoList: LiveData<List<Memo>> = _memoList
 
+    // 현재 수정 중인 Memo
     private val _editingMemo = MutableLiveData<Memo?>()
     val editingMemo: LiveData<Memo?> get() = _editingMemo
 
-    private val memoMap = mutableMapOf<Int, Memo>()
 
     fun getMyMemos() {
         memoRepository.getMyMemos(
@@ -72,7 +74,7 @@ class MemoViewModel @Inject constructor(
     }
 
     fun getMemo(memoId: Int): Memo? {
-        val memo = memoMap[memoId] ?: _memoList.value?.find { it.id == memoId }
+        val memo = _memoList.value?.find { it.id == memoId }
         if (memo != null) {
             Log.d("MemoViewModel", "getMemo($memoId) → ${memo.content}")
         } else {
@@ -81,14 +83,6 @@ class MemoViewModel @Inject constructor(
         return memo
     }
 
-    fun cacheSearchResultFromIds(memoIds: List<Int>) {
-        val allMemos = _memoList.value ?: return
-        val filtered = allMemos.filter { it.id in memoIds }
-        memoMap.putAll(filtered.associateBy { it.id })
-        filtered.forEach {
-            Log.d("MemoViewModel", "검색 캐싱됨: id=${it.id}, content=${it.content}")
-        }
-    }
 
     fun startEditing(memo: Memo) {
         _editingMemo.value = memo

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/MemoViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/MemoViewModel.kt
@@ -81,10 +81,12 @@ class MemoViewModel @Inject constructor(
         return memo
     }
 
-    fun cacheSearchResult(memos: List<Memo>) {
-        for (memo in memos) {
-            Log.d("MemoViewModel", "캐싱됨: id=${memo.id}, content=${memo.content}")
-            memoMap[memo.id] = memo
+    fun cacheSearchResultFromIds(memoIds: List<Int>) {
+        val allMemos = _memoList.value ?: return
+        val filtered = allMemos.filter { it.id in memoIds }
+        memoMap.putAll(filtered.associateBy { it.id })
+        filtered.forEach {
+            Log.d("MemoViewModel", "검색 캐싱됨: id=${it.id}, content=${it.content}")
         }
     }
 

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/SearchViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/SearchViewModel.kt
@@ -45,7 +45,7 @@ class SearchViewModel @Inject constructor(
             tagIds = emptyList(),
             startDate = null,
             endDate = null,
-            page = 0,
+            page = 1,
             callback = { result ->
                 _memoSearchResult.postValue(result)
             },

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/SearchViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/SearchViewModel.kt
@@ -16,7 +16,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SearchViewModel @Inject constructor(
-    private val memoRepository: MemoRepository,
+    private val memoRepository: MemoRepository
 ) : ViewModel() {
     private val _query = MutableStateFlow("")
     fun updateQuery(newQuery: String) {

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/SearchViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/SearchViewModel.kt
@@ -1,10 +1,10 @@
 package com.example.memowithtags.mainMemo.viewModel
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.memowithtags.common.model.Memo
 import com.example.memowithtags.mainMemo.repository.MemoRepository
 import com.example.memowithtags.mainMemo.repository.TagRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -25,8 +25,8 @@ class SearchViewModel @Inject constructor(
         _query.value = newQuery
     }
 
-    private val _memoSearchResult = MutableLiveData<List<Memo>>()
-    val memoSearchResult: LiveData<List<Memo>> = _memoSearchResult
+    private val _memoSearchResult = MutableLiveData<List<Int>>()
+    val memoSearchResult: LiveData<List<Int>> = _memoSearchResult
 
     init {
         viewModelScope.launch {
@@ -34,12 +34,18 @@ class SearchViewModel @Inject constructor(
                 .debounce(300)
                 .distinctUntilChanged()
                 .collectLatest { query ->
+                    Log.d("SearchViewModel", "검색 쿼리: $query")
                     performSearch(query)
                 }
         }
     }
 
     private fun performSearch(query: String) {
+        if (query.isBlank()) {
+            _memoSearchResult.postValue(emptyList())
+            return
+        }
+
         memo_repository.searchMemo(
             content = query,
             tagIds = emptyList(),
@@ -47,7 +53,7 @@ class SearchViewModel @Inject constructor(
             endDate = null,
             page = 1,
             callback = { result ->
-                _memoSearchResult.postValue(result)
+                _memoSearchResult.postValue(result.map { it.id })
             },
             onError = {
                 _memoSearchResult.postValue(emptyList()) // 실패 시 빈 리스트 처리

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/SearchViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/SearchViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.memowithtags.mainMemo.repository.MemoRepository
-import com.example.memowithtags.mainMemo.repository.TagRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -17,8 +16,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SearchViewModel @Inject constructor(
-    private val memo_repository: MemoRepository,
-    private val tag_repository: TagRepository
+    private val memoRepository: MemoRepository,
 ) : ViewModel() {
     private val _query = MutableStateFlow("")
     fun updateQuery(newQuery: String) {
@@ -27,6 +25,9 @@ class SearchViewModel @Inject constructor(
 
     private val _memoSearchResult = MutableLiveData<List<Int>>()
     val memoSearchResult: LiveData<List<Int>> = _memoSearchResult
+
+    private val _tagSearchResult = MutableLiveData<List<Int>>()
+    val tagSearchResult: LiveData<List<Int>> = _tagSearchResult
 
     init {
         viewModelScope.launch {
@@ -46,7 +47,7 @@ class SearchViewModel @Inject constructor(
             return
         }
 
-        memo_repository.searchMemo(
+        memoRepository.searchMemo(
             content = query,
             tagIds = emptyList(),
             startDate = null,

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/TagViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/TagViewModel.kt
@@ -12,15 +12,12 @@ import com.example.memowithtags.common.model.tagColors
 import com.example.memowithtags.mainMemo.repository.TagRepository
 import com.example.memowithtags.settings.repository.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @HiltViewModel
 class TagViewModel @Inject constructor(
@@ -95,7 +92,6 @@ class TagViewModel @Inject constructor(
         _query.value = ""
         _isSearching.value = false
     }
-
 
     fun createTag(name: String, colorHex: String) {
         tagRepository.createTag(

--- a/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/TagViewModel.kt
+++ b/app/src/main/java/com/example/memowithtags/mainMemo/viewModel/TagViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.memowithtags.common.model.AlphanumComparator
 import com.example.memowithtags.common.model.Tag
 import com.example.memowithtags.common.model.TagSortType
@@ -12,6 +13,14 @@ import com.example.memowithtags.mainMemo.repository.TagRepository
 import com.example.memowithtags.settings.repository.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class TagViewModel @Inject constructor(
@@ -19,16 +28,74 @@ class TagViewModel @Inject constructor(
     private val settingsRepository: SettingsRepository
 ) : ViewModel() {
 
+    private var initialized = false
+
+    // Tag 정보를 저장하는 List
     private val _tagList = MutableLiveData<List<Tag>>(emptyList())
     val tagList: LiveData<List<Tag>> = _tagList
 
+    // 선택된 Tag의 id를 저장하는 List
     private val _selectedTagIds = MutableLiveData<List<Int>>()
     val selectedTagIds: LiveData<List<Int>> = _selectedTagIds
 
-    private var initialized = false
-
     // 이름 정렬을 위한 collator
     private val collator = AlphanumComparator()
+
+    // 검색 중인지 여부를 저장하는 변수
+    private val _isSearching = MutableStateFlow(false)
+
+    // 검색된 Tag의 id를 저장하는 List
+    private val _searchTagIds = MutableLiveData<List<Int>>()
+    val searchTagIds: LiveData<List<Int>> = _searchTagIds
+
+    // 검색어를 저장하는 변수
+    private val _query = MutableStateFlow("")
+
+    // 검색된 Tag의 id를 저장하는 List
+    private val _tagSearchResult = MutableLiveData<List<Int>>()
+    val tagSearchResult: LiveData<List<Int>> = _tagSearchResult
+
+    fun updateQuery(newQuery: String) {
+        _query.value = newQuery
+    }
+
+    init {
+        viewModelScope.launch {
+            _query
+                .debounce(300)
+                .distinctUntilChanged()
+                .collectLatest { query ->
+                    performTagSearch(query)
+                }
+        }
+    }
+
+    fun setIsSearching(isSearching: Boolean) {
+        _isSearching.value = isSearching
+    }
+
+    private fun performTagSearch(query: String) {
+        if (!_isSearching.value) return
+
+        if (query.isBlank()) {
+            _tagSearchResult.postValue(emptyList())
+            return
+        }
+
+        val result = _tagList.value
+            ?.filter { it.name.contains(query, ignoreCase = true) }
+            ?.map { it.id }
+            ?: emptyList()
+
+        _tagSearchResult.postValue(result)
+    }
+
+    fun clearSearch() {
+        _tagSearchResult.postValue(emptyList())
+        _query.value = ""
+        _isSearching.value = false
+    }
+
 
     fun createTag(name: String, colorHex: String) {
         tagRepository.createTag(

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -70,7 +70,6 @@
         android:textSize="14sp"
         android:textColor="#A0A0A1"
         android:layout_margin="10dp"
-        android:visibility="gone"
         app:layout_constraintTop_toBottomOf="@id/topBar"
         app:layout_constraintStart_toStartOf="parent"/>
 
@@ -80,7 +79,6 @@
         android:layout_height="wrap_content"
         android:overScrollMode="never"
         android:scrollbars="horizontal"
-        android:visibility="gone"
         tools:listitem="@layout/item_tag"
         app:layout_constraintTop_toBottomOf="@id/tagTitleText"/>
 

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -93,7 +93,6 @@
         android:textSize="14sp"
         android:textColor="#A0A0A1"
         android:layout_margin="10dp"
-        android:visibility="gone"
         app:layout_constraintTop_toBottomOf="@id/searchtagRecyclerView"
         app:layout_constraintStart_toStartOf="parent"/>
 
@@ -103,7 +102,6 @@
         android:layout_height="0dp"
         android:clipToPadding="false"
         android:paddingBottom="72dp"
-        android:visibility="gone"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         android:layout_marginTop="6dp"
         app:layout_constraintTop_toBottomOf="@id/memoTitleText"

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -98,8 +98,8 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/searchmemoRecyclerView"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:clipToPadding="false"
         android:paddingBottom="72dp"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -10,28 +10,36 @@
         tools:layout="@layout/fragment_main_memo">
         <action
             android:id="@+id/action_mainMemo_to_editMemo"
-            app:destination="@id/editMemoFragment" />
+            app:destination="@id/editMemoFragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right"/>
         <action
             android:id="@+id/action_mainMemo_to_search"
-            app:destination="@id/searchFragment" />
+            app:destination="@id/searchFragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right"/>
     </fragment>
 
     <fragment
         android:id="@+id/editMemoFragment"
         android:name="com.example.memowithtags.mainMemo.fragments.EditMemoFragment"
-        tools:layout="@layout/fragment_edit_memo">
-        <action
-            android:id="@+id/action_editMemo_to_mainMemo"
-            app:destination="@id/mainMemoFragment" />
-    </fragment>
+        tools:layout="@layout/fragment_edit_memo"/>
 
     <fragment
         android:id="@+id/searchFragment"
         android:name="com.example.memowithtags.mainMemo.fragments.SearchFragment"
         tools:layout="@layout/fragment_search">
         <action
-            android:id="@+id/action_search_to_mainMemo"
-            app:destination="@id/mainMemoFragment" />
+            android:id="@+id/action_searchFragment_to_editMemoFragment"
+            app:destination="@id/editMemoFragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right"/>
     </fragment>
 
 </navigation>


### PR DESCRIPTION
추가적으로 태그 검색이랑 메모 펼쳤을 때 나오는 메모로 검색하는 기능 구현했습니다ㅏ

이게 태그 검색은 api가 없어서 클라이언트 단에서 처리해야 되는데 SearchViewModel이 tag에 관한 데이터 접근이 불가해서 태그 검색은 TagViewModel 안에 구현해놨습니다. 사실 이럴거면 SearchViewModel의 필요성이 딱히 없긴한데 나중에 검색 관련해서 추가할 사항들이 있을 수 있어서 놔뒀어요.

TagViewModel안에 tag 검색을 구현한게 좀 마음에 걸리긴 하는데 현재 아키텍쳐를 전반적으로 수정하지 않는 이상 이게 가장 간단한 것 같아서 해당 방식으로 구현하긴 했습니다. iOS에서는 처음에는 Tag, Memo 관련해서 모두 하나(?)의 ViewModel로 합쳐서 처리했다가 현재는 ViewModel보다 한 단계 아래에 있는 레이어를 추가해서 액티비티와 상관없이 작동하되 모든 데이터를 관리하는? 그런 아키텍쳐로 바꿨다고 하네요.

문제있으면 알려주시면 감사하겠습니다 :)